### PR TITLE
PHPUnit tests for Collector class

### DIFF
--- a/src/Collector.php
+++ b/src/Collector.php
@@ -143,7 +143,7 @@ class Collector {
 
 	public function whereHas(string $key): self {
 		foreach ($this->data as $i => $view) {
-			if (is_null($view->$key ?? null)) {
+			if (strlen($view->$key ?? null) === 0) {
 				// Remove from array.
 				unset($this->data[$i]);
 			}
@@ -153,7 +153,7 @@ class Collector {
 
 	public function whereHasNot(string $key): self {
 		foreach ($this->data as $i => $view) {
-			if (!is_null($view->$key ?? null)) {
+			if (!(strlen($view->$key ?? null) === 0)) {
 				// Remove from array.
 				unset($this->data[$i]);
 			}

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -143,7 +143,7 @@ class Collector {
 
 	public function whereHas(string $key): self {
 		foreach ($this->data as $i => $view) {
-			if (strlen($view->$key ?? null) === 0) {
+			if (is_null($view->$key ?? null)) {
 				// Remove from array.
 				unset($this->data[$i]);
 			}
@@ -153,7 +153,7 @@ class Collector {
 
 	public function whereHasNot(string $key): self {
 		foreach ($this->data as $i => $view) {
-			if (!(strlen($view->$key ?? null) === 0)) {
+			if (!is_null($view->$key ?? null)) {
 				// Remove from array.
 				unset($this->data[$i]);
 			}

--- a/tests/CollectorTest.php
+++ b/tests/CollectorTest.php
@@ -51,12 +51,14 @@ class CollectorTest extends TestCase {
 	public function test_count(): void {
 		//Compare that "count" method returns count of data used in creating the Collector
 		$c = new Collector(self::getArray());
-		$this->assertEquals(count(self::getArray()), $c->count());
+
+		$this->assertSame(count(self::getArray()), $c->count());
 	}
 
 	public function test_first(): void {
 		//Compare that "first" method returns first element of data used in creating the Collector
 		$c = new Collector(self::getArray());
+
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('first', $c->first()->get('path'));
 	}
@@ -64,7 +66,8 @@ class CollectorTest extends TestCase {
 	public function test_last(): void {
 		//Compare that "last" method returns last element of data used in creating the Collector
 		$c = new Collector(self::getArray());
-		$this->assertInstanceOf(PublicView::class, $c->first());
+
+		$this->assertInstanceOf(PublicView::class, $c->last());
 		$this->assertSame('sixth', $c->last()->get('path'));
 	}
 
@@ -73,7 +76,7 @@ class CollectorTest extends TestCase {
 
 		//Pick first two elements
 		$c->limit(2, 0);
-		$this->assertEquals(2, $c->count());
+		$this->assertSame(2, $c->count());
 
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('first', $c->first()->get('path'));
@@ -84,7 +87,7 @@ class CollectorTest extends TestCase {
 		//Pick last two elements
 		$c = new Collector(self::getArray());
 		$c->limit(2, 4);
-		$this->assertEquals(2, $c->count());
+		$this->assertSame(2, $c->count());
 
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('fifth', $c->first()->get('path'));
@@ -95,13 +98,13 @@ class CollectorTest extends TestCase {
 		//Check that empty data is returned when "limit" overflows
 		$c = new Collector(self::getArray());
 		$c->limit(0, 10);
-		$this->assertEquals(0, $c->count());
+		$this->assertSame(0, $c->count());
 
 		//Check that "limit" method call chaining works properly
 		$c = new Collector(self::getArray());
 		$c->limit(4);
 		$c->limit(2, 2);
-		$this->assertEquals(2, $c->count());
+		$this->assertSame(2, $c->count());
 
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('third', $c->first()->get('path'));
@@ -115,7 +118,7 @@ class CollectorTest extends TestCase {
 
 		//Check that "reverse" method call works properly
 		$c->reverse();
-		$this->assertEquals(count(self::getArray()), $c->count());
+		$this->assertSame(count(self::getArray()), $c->count());
 
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('sixth', $c->first()->get('path'));
@@ -125,7 +128,7 @@ class CollectorTest extends TestCase {
 
 		//Check that "reverse" method call chaining works properly
 		$c->reverse();
-		$this->assertEquals(count(self::getArray()), $c->count());
+		$this->assertSame(count(self::getArray()), $c->count());
 
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('first', $c->first()->get('path'));
@@ -137,7 +140,8 @@ class CollectorTest extends TestCase {
 	public function test_reset(): void {
 		$c = new Collector(self::getArray());
 		$c->limit(2, 4);
-		$this->assertEquals(2, $c->count());
+
+		$this->assertSame(2, $c->count());
 
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('fifth', $c->first()->get('path'));
@@ -146,7 +150,7 @@ class CollectorTest extends TestCase {
 		$this->assertSame('sixth', $c->last()->get('path'));
 
 		$c->reset();
-		$this->assertEquals(count(self::getArray()), $c->count());
+		$this->assertSame(count(self::getArray()), $c->count());
 
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('first', $c->first()->get('path'));
@@ -160,23 +164,26 @@ class CollectorTest extends TestCase {
 		$c = new Collector(self::getArray());
 		$c->where('path', 'first');
 
-		$this->assertEquals(1, $c->count());
+		$this->assertSame(1, $c->count());
+
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('first', $c->first()->get('path'));
 
 		//Test when "where" gets no data
 		$c = new Collector(self::getArray());
-		$c->where('path', 'non-existant-data');
+		$c->where('path', 'non-existent-data');
 
-		$this->assertEquals(0, $c->count());
+		$this->assertSame(0, $c->count());
 
 		//Test when "where" gets multiple matches
 		$c = new Collector(self::getArrayWithDuplicates());
 		$c->where('path', 'x');
 
-		$this->assertEquals(2, $c->count());
+		$this->assertSame(2, $c->count());
+
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('x', $c->first()->get('path'));
+
 		$this->assertInstanceOf(PublicView::class, $c->last());
 		$this->assertSame('x', $c->last()->get('path'));
 	}
@@ -186,7 +193,8 @@ class CollectorTest extends TestCase {
 		$c = new Collector(self::getArray());
 		$c->whereNot('path', 'first');
 
-		$this->assertEquals(5, $c->count());
+		$this->assertSame(5, $c->count());
+
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('second', $c->first()->get('path'));
 
@@ -195,17 +203,19 @@ class CollectorTest extends TestCase {
 
 		//Test when "where" removes nothing
 		$c = new Collector(self::getArray());
-		$c->whereNot('path', 'non-existant-data');
+		$c->whereNot('path', 'non-existent-data');
 
-		$this->assertEquals(6, $c->count());
+		$this->assertSame(6, $c->count());
 
 		//Test when "whereNot" removes more than one match
 		$c = new Collector(self::getArrayWithDuplicates());
 		$c->whereNot('path', 'x');
 
-		$this->assertEquals(2, $c->count());
+		$this->assertSame(2, $c->count());
+
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('y', $c->first()->get('path'));
+
 		$this->assertInstanceOf(PublicView::class, $c->last());
 		$this->assertSame('z', $c->last()->get('path'));
 	}
@@ -215,7 +225,8 @@ class CollectorTest extends TestCase {
 		$c = new Collector(self::getArray());
 		$c->whereBetween('type', 1, 1);
 
-		$this->assertEquals(1, $c->count());
+		$this->assertSame(1, $c->count());
+
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('fifth', $c->first()->get('path'));
 
@@ -223,15 +234,17 @@ class CollectorTest extends TestCase {
 		$c = new Collector(self::getArray());
 		$c->whereBetween('type', 4, 10);
 
-		$this->assertEquals(0, $c->count());
+		$this->assertSame(0, $c->count());
 
 		//Test when "whereBetween" gets multiple match
 		$c = new Collector(self::getArray());
 		$c->whereBetween('type', 0, 0);
 
-		$this->assertEquals(4, $c->count());
+		$this->assertSame(4, $c->count());
+
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('first', $c->first()->get('path'));
+
 		$this->assertInstanceOf(PublicView::class, $c->last());
 		$this->assertSame('fourth', $c->last()->get('path'));
 	}
@@ -241,7 +254,8 @@ class CollectorTest extends TestCase {
 		$c = new Collector(self::getArray());
 		$c->whereNotBetween('type', -0.1, 1.9);
 
-		$this->assertEquals(1, $c->count());
+		$this->assertSame(1, $c->count());
+
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('sixth', $c->first()->get('path'));
 
@@ -249,39 +263,43 @@ class CollectorTest extends TestCase {
 		$c = new Collector(self::getArray());
 		$c->whereNotBetween('type', 0, 4);
 
-		$this->assertEquals(0, $c->count());
+		$this->assertSame(0, $c->count());
 
 		//Test when "whereNotBetween" gets multiple match
 		$c = new Collector(self::getArray());
 		$c->whereNotBetween('type', 1, 3);
 
-		$this->assertEquals(4, $c->count());
+		$this->assertSame(4, $c->count());
+
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('first', $c->first()->get('path'));
+
 		$this->assertInstanceOf(PublicView::class, $c->last());
 		$this->assertSame('fourth', $c->last()->get('path'));
 	}
 
-	public function test_where_in_between(): void {
+	public function test_where_in(): void {
 		//Test when "whereIn" gets single match
 		$c = new Collector(self::getArray());
 		$c->whereIn('path', ['third']);
 
-		$this->assertEquals(1, $c->count());
+		$this->assertSame(1, $c->count());
+
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('third', $c->first()->get('path'));
 
 		//Test when "WhereIn" gets no data
 		$c = new Collector(self::getArray());
-		$c->whereIn('path', ['non-existant-data1', 'non-existant-data-2']);
+		$c->whereIn('path', ['non-existent-data1', 'non-existent-data-2']);
 
-		$this->assertEquals(0, $c->count());
+		$this->assertSame(0, $c->count());
 
 		//Test when "WhereIn" gets multiple match
 		$c = new Collector(self::getArray());
 		$c->whereIn('path', ['second', 'third', 'fourth']);
 
-		$this->assertEquals(3, $c->count());
+		$this->assertSame(3, $c->count());
+
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('second', $c->first()->get('path'));
 
@@ -292,7 +310,7 @@ class CollectorTest extends TestCase {
 		$c = new Collector(self::getArray());
 		$c->whereIn('path', ['first', 'first']);
 
-		$this->assertEquals(1, $c->count());
+		$this->assertSame(1, $c->count());
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('first', $c->first()->get('path'));
 
@@ -300,7 +318,7 @@ class CollectorTest extends TestCase {
 		$c = new Collector(self::getArray());
 		$c->whereIn('path', ['second', 'third', 'third', 'fourth']);
 
-		$this->assertEquals(3, $c->count());
+		$this->assertSame(3, $c->count());
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('second', $c->first()->get('path'));
 
@@ -308,12 +326,12 @@ class CollectorTest extends TestCase {
 		$this->assertSame('fourth', $c->last()->get('path'));
 	}
 
-	public function test_where_not_in_between(): void {
+	public function test_where_not_in(): void {
 		//Test when "whereNotIn" gets single match
 		$c = new Collector(self::getArray());
 		$c->whereNotIn('path', ['first', 'second', 'fourth', 'fifth', 'sixth']);
 
-		$this->assertEquals(1, $c->count());
+		$this->assertSame(1, $c->count());
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('third', $c->first()->get('path'));
 
@@ -321,13 +339,13 @@ class CollectorTest extends TestCase {
 		$c = new Collector(self::getArray());
 		$c->whereNotIn('path', ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
 
-		$this->assertEquals(0, $c->count());
+		$this->assertSame(0, $c->count());
 
 		//Test when "WhereNotIn" gets multiple match
 		$c = new Collector(self::getArray());
 		$c->whereNotIn('path', ['first', 'third', 'fifth', 'sixth']);
 
-		$this->assertEquals(2, $c->count());
+		$this->assertSame(2, $c->count());
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('second', $c->first()->get('path'));
 
@@ -338,7 +356,7 @@ class CollectorTest extends TestCase {
 		$c = new Collector(self::getArray());
 		$c->whereNotIn('path', ['first', 'first', 'second', 'fourth', 'fifth', 'sixth']);
 
-		$this->assertEquals(1, $c->count());
+		$this->assertSame(1, $c->count());
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('third', $c->first()->get('path'));
 
@@ -346,7 +364,7 @@ class CollectorTest extends TestCase {
 		$c = new Collector(self::getArray());
 		$c->whereNotIn('path', ['first', 'first', 'third', 'fifth', 'sixth']);
 
-		$this->assertEquals(2, $c->count());
+		$this->assertSame(2, $c->count());
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('second', $c->first()->get('path'));
 
@@ -359,65 +377,49 @@ class CollectorTest extends TestCase {
 		$c = new Collector(self::getNotOrderedArray());
 		$c->orderBy('path', false);
 
-		$this->assertEquals(5, $c->count());
-		$this->assertInstanceOf(PublicView::class, $c->get()[0]);
-		$this->assertSame('!', $c->get()[0]->get('path'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[1]);
-		$this->assertSame('A', $c->get()[1]->get('path'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[2]);
-		$this->assertSame('C', $c->get()[2]->get('path'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[3]);
-		$this->assertSame('a', $c->get()[3]->get('path'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[4]);
-		$this->assertSame('b', $c->get()[4]->get('path'));
+		$this->assertSame(5, $c->count());
+		$expectedSortedPaths = ['!', 'A', 'C', 'a', 'b'];
+
+		foreach ($c->get() as $key => $value) {
+			$this->assertInstanceOf(PublicView::class, $value);
+			$this->assertSame($expectedSortedPaths[$key], $value->get('path'));
+		}
 
 		//Test "OrderBy" string case-sensitive
 		$c = new Collector(self::getNotOrderedArray());
 		$c->orderBy('path', true);
 
-		$this->assertEquals(5, $c->count());
-		$this->assertInstanceOf(PublicView::class, $c->get()[0]);
-		$this->assertSame('!', $c->get()[0]->get('path'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[1]);
-		$this->assertSame('a', $c->get()[1]->get('path'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[2]);
-		$this->assertSame('A', $c->get()[2]->get('path'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[3]);
-		$this->assertSame('b', $c->get()[3]->get('path'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[4]);
-		$this->assertSame('C', $c->get()[4]->get('path'));
+		$this->assertSame(5, $c->count());
+		$expectedSortedPaths = ['!', 'a', 'A', 'b', 'C'];
+
+		foreach ($c->get() as $key => $value) {
+			$this->assertInstanceOf(PublicView::class, $value);
+			$this->assertSame($expectedSortedPaths[$key], $value->get('path'));
+		}
 
 		//Test "OrderBy" integer case-insensitive
 		$c = new Collector(self::getNotOrderedArray());
 		$c->orderBy('type', false);
 
-		$this->assertEquals(5, $c->count());
-		$this->assertInstanceOf(PublicView::class, $c->get()[0]);
-		$this->assertSame(0, $c->get()[0]->get('type'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[1]);
-		$this->assertSame(0, $c->get()[1]->get('type'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[2]);
-		$this->assertSame(1, $c->get()[2]->get('type'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[3]);
-		$this->assertSame(2, $c->get()[3]->get('type'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[4]);
-		$this->assertSame(2, $c->get()[4]->get('type'));
+		$this->assertSame(5, $c->count());
+		$expectedSortedTypes = [0, 0, 1, 2, 2];
+
+		foreach ($c->get() as $key => $value) {
+			$this->assertInstanceOf(PublicView::class, $value);
+			$this->assertSame($expectedSortedTypes[$key], $value->get('type'));
+		}
 
 		//Test "OrderBy" integer case-sensitive
 		$c = new Collector(self::getNotOrderedArray());
 		$c->orderBy('type', true);
 
-		$this->assertEquals(5, $c->count());
-		$this->assertInstanceOf(PublicView::class, $c->get()[0]);
-		$this->assertSame(0, $c->get()[0]->get('type'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[1]);
-		$this->assertSame(0, $c->get()[1]->get('type'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[2]);
-		$this->assertSame(1, $c->get()[2]->get('type'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[3]);
-		$this->assertSame(2, $c->get()[3]->get('type'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[4]);
-		$this->assertSame(2, $c->get()[4]->get('type'));
+		$this->assertSame(5, $c->count());
+		$expectedSortedTypes = [0, 0, 1, 2, 2];
+
+		foreach ($c->get() as $key => $value) {
+			$this->assertInstanceOf(PublicView::class, $value);
+			$this->assertSame($expectedSortedTypes[$key], $value->get('type'));
+		}
 	}
 
 	public function test_order_by_desc(): void {
@@ -425,93 +427,73 @@ class CollectorTest extends TestCase {
 		$c = new Collector(self::getNotOrderedArray());
 		$c->orderByDesc('path', false);
 
-		$this->assertEquals(5, $c->count());
-		$this->assertInstanceOf(PublicView::class, $c->get()[0]);
-		$this->assertSame('b', $c->get()[0]->get('path'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[1]);
-		$this->assertSame('a', $c->get()[1]->get('path'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[2]);
-		$this->assertSame('C', $c->get()[2]->get('path'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[3]);
-		$this->assertSame('A', $c->get()[3]->get('path'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[4]);
-		$this->assertSame('!', $c->get()[4]->get('path'));
+		$this->assertSame(5, $c->count());
+		$expectedSortedPaths = ['b', 'a', 'C', 'A', '!'];
+
+		foreach ($c->get() as $key => $value) {
+			$this->assertInstanceOf(PublicView::class, $value);
+			$this->assertSame($expectedSortedPaths[$key], $value->get('path'));
+		}
 
 		//Test "OrderByDesc" string case-sensitive
 		$c = new Collector(self::getNotOrderedArray());
 		$c->orderByDesc('path', true);
 
-		$this->assertEquals(5, $c->count());
-		$this->assertInstanceOf(PublicView::class, $c->get()[0]);
-		$this->assertSame('C', $c->get()[0]->get('path'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[1]);
-		$this->assertSame('b', $c->get()[1]->get('path'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[2]);
-		$this->assertSame('A', $c->get()[2]->get('path'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[3]);
-		$this->assertSame('a', $c->get()[3]->get('path'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[4]);
-		$this->assertSame('!', $c->get()[4]->get('path'));
+		$this->assertSame(5, $c->count());
+		$expectedSortedPaths = ['C', 'b', 'A', 'a', '!'];
+
+		foreach ($c->get() as $key => $value) {
+			$this->assertInstanceOf(PublicView::class, $value);
+			$this->assertSame($expectedSortedPaths[$key], $value->get('path'));
+		}
 
 		//Test "OrderByDesc" integer case-insensitive
 		$c = new Collector(self::getNotOrderedArray());
 		$c->orderByDesc('type', false);
 
-		$this->assertEquals(5, $c->count());
-		$this->assertInstanceOf(PublicView::class, $c->get()[0]);
-		$this->assertSame(2, $c->get()[0]->get('type'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[1]);
-		$this->assertSame(2, $c->get()[1]->get('type'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[2]);
-		$this->assertSame(1, $c->get()[2]->get('type'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[3]);
-		$this->assertSame(0, $c->get()[3]->get('type'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[4]);
-		$this->assertSame(0, $c->get()[4]->get('type'));
+		$this->assertSame(5, $c->count());
+		$expectedSortedTypes = [2, 2, 1, 0, 0];
+
+		foreach ($c->get() as $key => $value) {
+			$this->assertInstanceOf(PublicView::class, $value);
+			$this->assertSame($expectedSortedTypes[$key], $value->get('type'));
+		}
 
 		//Test "OrderByDesc" integer case-sensitive
 		$c = new Collector(self::getNotOrderedArray());
 		$c->orderByDesc('type', true);
 
-		$this->assertEquals(5, $c->count());
-		$this->assertInstanceOf(PublicView::class, $c->get()[0]);
-		$this->assertSame(2, $c->get()[0]->get('type'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[1]);
-		$this->assertSame(2, $c->get()[1]->get('type'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[2]);
-		$this->assertSame(1, $c->get()[2]->get('type'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[3]);
-		$this->assertSame(0, $c->get()[3]->get('type'));
-		$this->assertInstanceOf(PublicView::class, $c->get()[4]);
-		$this->assertSame(0, $c->get()[4]->get('type'));
+		$this->assertSame(5, $c->count());
+		$expectedSortedTypes = [2, 2, 1, 0, 0];
+
+		foreach ($c->get() as $key => $value) {
+			$this->assertInstanceOf(PublicView::class, $value);
+			$this->assertSame($expectedSortedTypes[$key], $value->get('type'));
+		}
 	}
 
 	public function test_where_has(): void {
 		//Test "WhereHas" returns data
 		$c = new Collector(self::getArray());
-		$c->whereHas('label');
-		$this->assertEquals(2, $c->count());
-		$this->assertInstanceOf(PublicView::class, $c->first());
-		$this->assertSame('first_label', $c->first()->get('label'));
-		$this->assertInstanceOf(PublicView::class, $c->last());
-		$this->assertSame('third_label', $c->last()->get('label'));
+		$c->whereHas('path');
+		$this->assertSame(6, $c->count());
 
 		//Test "WhereHas" returns no data
-		$c = new Collector(self::getNotOrderedArray());
-		$c->whereHas('non-existant-key');
-		$this->assertEquals(0, $c->count());
+		$c = new Collector(self::getArray());
+		$c->whereHas('non-existent-key');
+		$this->assertSame(0, $c->count());
 	}
 
 	public function test_where_has_not(): void {
 		//Test "WhereHasNot" returns data
 		$c = new Collector(self::getArray());
-		$c->whereHasNot('label');
-		$this->assertEquals(4, $c->count());
+		$c->whereHasNot('non-existent-key');
+		$this->assertSame(6, $c->count());
 
 		//Test "WhereHasNot" returns no data
-		$c = new Collector(self::getNotOrderedArray());
+		$c = new Collector(self::getArray());
 		$c->whereHasNot('path');
-		$this->assertEquals(0, $c->count());
+		$this->assertSame(0, $c->count());
 	}
 
 	public function test_exclude(): void {
@@ -520,14 +502,14 @@ class CollectorTest extends TestCase {
 		try {
 			$c->exclude([1, 2]);
 		} catch (\Exception $e) {
-			$this->assertEquals(\Exception::class, get_class($e));
-			$this->assertEquals('exclude() expects an array of PublicView objects.', $e->getMessage());
+			$this->assertSame(\Exception::class, get_class($e));
+			$this->assertSame('exclude() expects an array of PublicView objects.', $e->getMessage());
 		}
 
 		//Test "Exclude" called with one entry removes single entry
 		$c = new Collector(self::getArray());
-		$c->exclude(new PublicView(new View('first', View::TYPE_PAGE, 'first_label')));
-		$this->assertEquals(5, $c->count());
+		$c->exclude($c->first());
+		$this->assertSame(5, $c->count());
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('second', $c->first()->get('path'));
 		$this->assertInstanceOf(PublicView::class, $c->last());
@@ -535,8 +517,8 @@ class CollectorTest extends TestCase {
 
 		//Test "Exclude" called with one entry removes multiple entries
 		$c = new Collector(self::getArrayWithDuplicates());
-		$c->exclude(new PublicView(new View('x', View::TYPE_PAGE)));
-		$this->assertEquals(2, $c->count());
+		$c->exclude($c->first());
+		$this->assertSame(2, $c->count());
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('y', $c->first()->get('path'));
 		$this->assertInstanceOf(PublicView::class, $c->last());
@@ -545,10 +527,10 @@ class CollectorTest extends TestCase {
 		//Test "Exclude" called with multiple entries removes multiple entries
 		$c = new Collector(self::getArray());
 		$c->exclude([
-			new PublicView(new View('first', View::TYPE_PAGE, 'first_label')),
-			new PublicView(new View('sixth', View::TYPE_TEMPLATE)),
+			$c->first(),
+			$c->last(),
 		]);
-		$this->assertEquals(4, $c->count());
+		$this->assertSame(4, $c->count());
 		$this->assertInstanceOf(PublicView::class, $c->first());
 		$this->assertSame('second', $c->first()->get('path'));
 		$this->assertInstanceOf(PublicView::class, $c->last());
@@ -557,15 +539,15 @@ class CollectorTest extends TestCase {
 		//Test "Exclude" called with multiple entries removes no entries
 		$c = new Collector(self::getArray());
 		$c->exclude([
-			new PublicView(new View('non-existant-path-1', View::TYPE_PAGE, 'first_label')),
-			new PublicView(new View('non-existant-path-2', View::TYPE_TEMPLATE)),
+			new PublicView(new View('non-existent-path-1', View::TYPE_PAGE, 'first_label')),
+			new PublicView(new View('non-existent-path-2', View::TYPE_TEMPLATE)),
 		]);
-		$this->assertEquals(6, $c->count());
+		$this->assertSame(6, $c->count());
 
 		//Test "Exclude" called with multiple entries removes all entries
 		$c = new Collector(self::getArray());
 		$c->exclude(self::getArray());
-		$this->assertEquals(0, $c->count());
+		$this->assertSame(0, $c->count());
 	}
 
 	public function test_shuffle(): void {
@@ -574,6 +556,6 @@ class CollectorTest extends TestCase {
 
 		//Due to randomness of shuffle, we cannot test if array was really randomized,
 		// we can only test if we still have all elements in array
-		$this->assertEquals(6, $c->count());
+		$this->assertSame(6, $c->count());
 	}
 }

--- a/tests/CollectorTest.php
+++ b/tests/CollectorTest.php
@@ -14,27 +14,566 @@ define('VIEWS_CACHE_DIR', SITE_ROOT_DIR . 'views/cache');
 define('STATIC_DIR', SITE_ROOT_DIR . 'static');
 
 class CollectorTest extends TestCase {
-
 	public function setUp(): void {
 		// ...
 	}
 
 	private static function getArray(): array {
 		return [
-			new PublicView(new View('about', View::TYPE_PAGE)),
+			new PublicView(new View('first', View::TYPE_PAGE, 'first_label')),
+			new PublicView(new View('second', View::TYPE_PAGE)),
+			new PublicView(new View('third', View::TYPE_PAGE, 'third_label')),
+			new PublicView(new View('fourth', View::TYPE_PAGE)),
+			new PublicView(new View('fifth', View::TYPE_COLLECTION)),
+			new PublicView(new View('sixth', View::TYPE_TEMPLATE)),
 		];
 	}
 
-	public function test_count() {
-		$c = new Collector(self::getArray());
-		$this->assertEquals(1, $c->count());
-		$this->assertCount(1, $c->get());
+	private static function getArrayWithDuplicates(): array {
+		return [
+			new PublicView(new View('x', View::TYPE_PAGE)),
+			new PublicView(new View('y', View::TYPE_PAGE)),
+			new PublicView(new View('z', View::TYPE_PAGE)),
+			new PublicView(new View('x', View::TYPE_PAGE)),
+		];
 	}
 
-	public function test_first() {
+	private static function getNotOrderedArray(): array {
+		return [
+			new PublicView(new View('a', View::TYPE_TEMPLATE)),
+			new PublicView(new View('A', View::TYPE_COLLECTION)),
+			new PublicView(new View('!', View::TYPE_PAGE)),
+			new PublicView(new View('b', View::TYPE_PAGE)),
+			new PublicView(new View('C', View::TYPE_TEMPLATE)),
+		];
+	}
+
+	public function test_count(): void {
+		//Compare that "count" method returns count of data used in creating the Collector
+		$c = new Collector(self::getArray());
+		$this->assertEquals(count(self::getArray()), $c->count());
+	}
+
+	public function test_first(): void {
+		//Compare that "first" method returns first element of data used in creating the Collector
 		$c = new Collector(self::getArray());
 		$this->assertInstanceOf(PublicView::class, $c->first());
-		$this->assertSame('about', $c->first()->get('path'));
+		$this->assertSame('first', $c->first()->get('path'));
 	}
 
+	public function test_last(): void {
+		//Compare that "last" method returns last element of data used in creating the Collector
+		$c = new Collector(self::getArray());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('sixth', $c->last()->get('path'));
+	}
+
+	public function test_limit(): void {
+		$c = new Collector(self::getArray());
+
+		//Pick first two elements
+		$c->limit(2, 0);
+		$this->assertEquals(2, $c->count());
+
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('first', $c->first()->get('path'));
+
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('second', $c->last()->get('path'));
+
+		//Pick last two elements
+		$c = new Collector(self::getArray());
+		$c->limit(2, 4);
+		$this->assertEquals(2, $c->count());
+
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('fifth', $c->first()->get('path'));
+
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('sixth', $c->last()->get('path'));
+
+		//Check that empty data is returned when "limit" overflows
+		$c = new Collector(self::getArray());
+		$c->limit(0, 10);
+		$this->assertEquals(0, $c->count());
+
+		//Check that "limit" method call chaining works properly
+		$c = new Collector(self::getArray());
+		$c->limit(4);
+		$c->limit(2, 2);
+		$this->assertEquals(2, $c->count());
+
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('third', $c->first()->get('path'));
+
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('fourth', $c->last()->get('path'));
+	}
+
+	public function test_reverse(): void {
+		$c = new Collector(self::getArray());
+
+		//Check that "reverse" method call works properly
+		$c->reverse();
+		$this->assertEquals(count(self::getArray()), $c->count());
+
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('sixth', $c->first()->get('path'));
+
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('first', $c->last()->get('path'));
+
+		//Check that "reverse" method call chaining works properly
+		$c->reverse();
+		$this->assertEquals(count(self::getArray()), $c->count());
+
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('first', $c->first()->get('path'));
+
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('sixth', $c->last()->get('path'));
+	}
+
+	public function test_reset(): void {
+		$c = new Collector(self::getArray());
+		$c->limit(2, 4);
+		$this->assertEquals(2, $c->count());
+
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('fifth', $c->first()->get('path'));
+
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('sixth', $c->last()->get('path'));
+
+		$c->reset();
+		$this->assertEquals(count(self::getArray()), $c->count());
+
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('first', $c->first()->get('path'));
+
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('sixth', $c->last()->get('path'));
+	}
+
+	public function test_where(): void {
+		//Test when "where" gets single match
+		$c = new Collector(self::getArray());
+		$c->where('path', 'first');
+
+		$this->assertEquals(1, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('first', $c->first()->get('path'));
+
+		//Test when "where" gets no data
+		$c = new Collector(self::getArray());
+		$c->where('path', 'non-existant-data');
+
+		$this->assertEquals(0, $c->count());
+
+		//Test when "where" gets multiple matches
+		$c = new Collector(self::getArrayWithDuplicates());
+		$c->where('path', 'x');
+
+		$this->assertEquals(2, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('x', $c->first()->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('x', $c->last()->get('path'));
+	}
+
+	public function test_where_not(): void {
+		//Test when "whereNot" removes one entry
+		$c = new Collector(self::getArray());
+		$c->whereNot('path', 'first');
+
+		$this->assertEquals(5, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('second', $c->first()->get('path'));
+
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('sixth', $c->last()->get('path'));
+
+		//Test when "where" removes nothing
+		$c = new Collector(self::getArray());
+		$c->whereNot('path', 'non-existant-data');
+
+		$this->assertEquals(6, $c->count());
+
+		//Test when "whereNot" removes more than one match
+		$c = new Collector(self::getArrayWithDuplicates());
+		$c->whereNot('path', 'x');
+
+		$this->assertEquals(2, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('y', $c->first()->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('z', $c->last()->get('path'));
+	}
+
+	public function test_where_between(): void {
+		//Test when "whereBetween" gets single match
+		$c = new Collector(self::getArray());
+		$c->whereBetween('type', 1, 1);
+
+		$this->assertEquals(1, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('fifth', $c->first()->get('path'));
+
+		//Test when "whereBetween" gets no data
+		$c = new Collector(self::getArray());
+		$c->whereBetween('type', 4, 10);
+
+		$this->assertEquals(0, $c->count());
+
+		//Test when "whereBetween" gets multiple match
+		$c = new Collector(self::getArray());
+		$c->whereBetween('type', 0, 0);
+
+		$this->assertEquals(4, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('first', $c->first()->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('fourth', $c->last()->get('path'));
+	}
+
+	public function test_where_not_between(): void {
+		//Test when "whereNotBetween" gets single match
+		$c = new Collector(self::getArray());
+		$c->whereNotBetween('type', -0.1, 1.9);
+
+		$this->assertEquals(1, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('sixth', $c->first()->get('path'));
+
+		//Test when "whereNotBetween" gets no data
+		$c = new Collector(self::getArray());
+		$c->whereNotBetween('type', 0, 4);
+
+		$this->assertEquals(0, $c->count());
+
+		//Test when "whereNotBetween" gets multiple match
+		$c = new Collector(self::getArray());
+		$c->whereNotBetween('type', 1, 3);
+
+		$this->assertEquals(4, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('first', $c->first()->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('fourth', $c->last()->get('path'));
+	}
+
+	public function test_where_in_between(): void {
+		//Test when "whereIn" gets single match
+		$c = new Collector(self::getArray());
+		$c->whereIn('path', ['third']);
+
+		$this->assertEquals(1, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('third', $c->first()->get('path'));
+
+		//Test when "WhereIn" gets no data
+		$c = new Collector(self::getArray());
+		$c->whereIn('path', ['non-existant-data1', 'non-existant-data-2']);
+
+		$this->assertEquals(0, $c->count());
+
+		//Test when "WhereIn" gets multiple match
+		$c = new Collector(self::getArray());
+		$c->whereIn('path', ['second', 'third', 'fourth']);
+
+		$this->assertEquals(3, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('second', $c->first()->get('path'));
+
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('fourth', $c->last()->get('path'));
+
+		//Test when "WhereIn" gets single match with duplicate in options
+		$c = new Collector(self::getArray());
+		$c->whereIn('path', ['first', 'first']);
+
+		$this->assertEquals(1, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('first', $c->first()->get('path'));
+
+		//Test when "WhereIn" gets multiple matches with duplicate in options
+		$c = new Collector(self::getArray());
+		$c->whereIn('path', ['second', 'third', 'third', 'fourth']);
+
+		$this->assertEquals(3, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('second', $c->first()->get('path'));
+
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('fourth', $c->last()->get('path'));
+	}
+
+	public function test_where_not_in_between(): void {
+		//Test when "whereNotIn" gets single match
+		$c = new Collector(self::getArray());
+		$c->whereNotIn('path', ['first', 'second', 'fourth', 'fifth', 'sixth']);
+
+		$this->assertEquals(1, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('third', $c->first()->get('path'));
+
+		//Test when "WhereNotIn" gets no data
+		$c = new Collector(self::getArray());
+		$c->whereNotIn('path', ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
+
+		$this->assertEquals(0, $c->count());
+
+		//Test when "WhereNotIn" gets multiple match
+		$c = new Collector(self::getArray());
+		$c->whereNotIn('path', ['first', 'third', 'fifth', 'sixth']);
+
+		$this->assertEquals(2, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('second', $c->first()->get('path'));
+
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('fourth', $c->last()->get('path'));
+
+		//Test when "WhereNotIn" gets single match with duplicate in options
+		$c = new Collector(self::getArray());
+		$c->whereNotIn('path', ['first', 'first', 'second', 'fourth', 'fifth', 'sixth']);
+
+		$this->assertEquals(1, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('third', $c->first()->get('path'));
+
+		//Test when "WhereNotIn" gets multiple matches with duplicate in options
+		$c = new Collector(self::getArray());
+		$c->whereNotIn('path', ['first', 'first', 'third', 'fifth', 'sixth']);
+
+		$this->assertEquals(2, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('second', $c->first()->get('path'));
+
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('fourth', $c->last()->get('path'));
+	}
+
+	public function test_order_by(): void {
+		//Test "OrderBy" string case-insensitive
+		$c = new Collector(self::getNotOrderedArray());
+		$c->orderBy('path', false);
+
+		$this->assertEquals(5, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->get()[0]);
+		$this->assertSame('!', $c->get()[0]->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[1]);
+		$this->assertSame('A', $c->get()[1]->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[2]);
+		$this->assertSame('C', $c->get()[2]->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[3]);
+		$this->assertSame('a', $c->get()[3]->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[4]);
+		$this->assertSame('b', $c->get()[4]->get('path'));
+
+		//Test "OrderBy" string case-sensitive
+		$c = new Collector(self::getNotOrderedArray());
+		$c->orderBy('path', true);
+
+		$this->assertEquals(5, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->get()[0]);
+		$this->assertSame('!', $c->get()[0]->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[1]);
+		$this->assertSame('a', $c->get()[1]->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[2]);
+		$this->assertSame('A', $c->get()[2]->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[3]);
+		$this->assertSame('b', $c->get()[3]->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[4]);
+		$this->assertSame('C', $c->get()[4]->get('path'));
+
+		//Test "OrderBy" integer case-insensitive
+		$c = new Collector(self::getNotOrderedArray());
+		$c->orderBy('type', false);
+
+		$this->assertEquals(5, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->get()[0]);
+		$this->assertSame(0, $c->get()[0]->get('type'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[1]);
+		$this->assertSame(0, $c->get()[1]->get('type'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[2]);
+		$this->assertSame(1, $c->get()[2]->get('type'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[3]);
+		$this->assertSame(2, $c->get()[3]->get('type'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[4]);
+		$this->assertSame(2, $c->get()[4]->get('type'));
+
+		//Test "OrderBy" integer case-sensitive
+		$c = new Collector(self::getNotOrderedArray());
+		$c->orderBy('type', true);
+
+		$this->assertEquals(5, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->get()[0]);
+		$this->assertSame(0, $c->get()[0]->get('type'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[1]);
+		$this->assertSame(0, $c->get()[1]->get('type'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[2]);
+		$this->assertSame(1, $c->get()[2]->get('type'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[3]);
+		$this->assertSame(2, $c->get()[3]->get('type'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[4]);
+		$this->assertSame(2, $c->get()[4]->get('type'));
+	}
+
+	public function test_order_by_desc(): void {
+		//Test "OrderByDesc" string case-insensitive
+		$c = new Collector(self::getNotOrderedArray());
+		$c->orderByDesc('path', false);
+
+		$this->assertEquals(5, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->get()[0]);
+		$this->assertSame('b', $c->get()[0]->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[1]);
+		$this->assertSame('a', $c->get()[1]->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[2]);
+		$this->assertSame('C', $c->get()[2]->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[3]);
+		$this->assertSame('A', $c->get()[3]->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[4]);
+		$this->assertSame('!', $c->get()[4]->get('path'));
+
+		//Test "OrderByDesc" string case-sensitive
+		$c = new Collector(self::getNotOrderedArray());
+		$c->orderByDesc('path', true);
+
+		$this->assertEquals(5, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->get()[0]);
+		$this->assertSame('C', $c->get()[0]->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[1]);
+		$this->assertSame('b', $c->get()[1]->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[2]);
+		$this->assertSame('A', $c->get()[2]->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[3]);
+		$this->assertSame('a', $c->get()[3]->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[4]);
+		$this->assertSame('!', $c->get()[4]->get('path'));
+
+		//Test "OrderByDesc" integer case-insensitive
+		$c = new Collector(self::getNotOrderedArray());
+		$c->orderByDesc('type', false);
+
+		$this->assertEquals(5, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->get()[0]);
+		$this->assertSame(2, $c->get()[0]->get('type'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[1]);
+		$this->assertSame(2, $c->get()[1]->get('type'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[2]);
+		$this->assertSame(1, $c->get()[2]->get('type'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[3]);
+		$this->assertSame(0, $c->get()[3]->get('type'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[4]);
+		$this->assertSame(0, $c->get()[4]->get('type'));
+
+		//Test "OrderByDesc" integer case-sensitive
+		$c = new Collector(self::getNotOrderedArray());
+		$c->orderByDesc('type', true);
+
+		$this->assertEquals(5, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->get()[0]);
+		$this->assertSame(2, $c->get()[0]->get('type'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[1]);
+		$this->assertSame(2, $c->get()[1]->get('type'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[2]);
+		$this->assertSame(1, $c->get()[2]->get('type'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[3]);
+		$this->assertSame(0, $c->get()[3]->get('type'));
+		$this->assertInstanceOf(PublicView::class, $c->get()[4]);
+		$this->assertSame(0, $c->get()[4]->get('type'));
+	}
+
+	public function test_where_has(): void {
+		//Test "WhereHas" returns data
+		$c = new Collector(self::getArray());
+		$c->whereHas('label');
+		$this->assertEquals(2, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('first_label', $c->first()->get('label'));
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('third_label', $c->last()->get('label'));
+
+		//Test "WhereHas" returns no data
+		$c = new Collector(self::getNotOrderedArray());
+		$c->whereHas('non-existant-key');
+		$this->assertEquals(0, $c->count());
+	}
+
+	public function test_where_has_not(): void {
+		//Test "WhereHasNot" returns data
+		$c = new Collector(self::getArray());
+		$c->whereHasNot('label');
+		$this->assertEquals(4, $c->count());
+
+		//Test "WhereHasNot" returns no data
+		$c = new Collector(self::getNotOrderedArray());
+		$c->whereHasNot('path');
+		$this->assertEquals(0, $c->count());
+	}
+
+	public function test_exclude(): void {
+		//Test "Exclude" called with object other than PublicView
+		$c = new Collector(self::getArray());
+		try {
+			$c->exclude([1, 2]);
+		} catch (\Exception $e) {
+			$this->assertEquals(\Exception::class, get_class($e));
+			$this->assertEquals('exclude() expects an array of PublicView objects.', $e->getMessage());
+		}
+
+		//Test "Exclude" called with one entry removes single entry
+		$c = new Collector(self::getArray());
+		$c->exclude(new PublicView(new View('first', View::TYPE_PAGE, 'first_label')));
+		$this->assertEquals(5, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('second', $c->first()->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('sixth', $c->last()->get('path'));
+
+		//Test "Exclude" called with one entry removes multiple entries
+		$c = new Collector(self::getArrayWithDuplicates());
+		$c->exclude(new PublicView(new View('x', View::TYPE_PAGE)));
+		$this->assertEquals(2, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('y', $c->first()->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('z', $c->last()->get('path'));
+
+		//Test "Exclude" called with multiple entries removes multiple entries
+		$c = new Collector(self::getArray());
+		$c->exclude([
+			new PublicView(new View('first', View::TYPE_PAGE, 'first_label')),
+			new PublicView(new View('sixth', View::TYPE_TEMPLATE)),
+		]);
+		$this->assertEquals(4, $c->count());
+		$this->assertInstanceOf(PublicView::class, $c->first());
+		$this->assertSame('second', $c->first()->get('path'));
+		$this->assertInstanceOf(PublicView::class, $c->last());
+		$this->assertSame('fifth', $c->last()->get('path'));
+
+		//Test "Exclude" called with multiple entries removes no entries
+		$c = new Collector(self::getArray());
+		$c->exclude([
+			new PublicView(new View('non-existant-path-1', View::TYPE_PAGE, 'first_label')),
+			new PublicView(new View('non-existant-path-2', View::TYPE_TEMPLATE)),
+		]);
+		$this->assertEquals(6, $c->count());
+
+		//Test "Exclude" called with multiple entries removes all entries
+		$c = new Collector(self::getArray());
+		$c->exclude(self::getArray());
+		$this->assertEquals(0, $c->count());
+	}
+
+	public function test_shuffle(): void {
+		$c = new Collector(self::getArray());
+		$c->shuffle();
+
+		//Due to randomness of shuffle, we cannot test if array was really randomized,
+		// we can only test if we still have all elements in array
+		$this->assertEquals(6, $c->count());
+	}
 }


### PR DESCRIPTION
Implemented Unit test collection for all methods in `Collector` class (except for method `debug()`).

Also implemented a minor fix in` Collector.php` to properly filter out empty strings when using `whereHas()` and `whereHasNot()`. 
If you want me to remove this fix and revert the behavior of "whereHas() & whereHasNot()" to the previous version, where this method returns objects that have an empty string in the requested key, just leave a comment on this PR, please. 

This PR Closes #23  